### PR TITLE
New defaults & shit like that

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -26,7 +26,6 @@ TEXTUAL_INVERSION_PATHS = finders.find_textual_inversions("textual_inversions")
 
 SCHEDULER_NAMES = SDXLCompatibleSchedulers.get_names()
 
-
 DEFAULT_MODEL = MODEL_NAMES[0]
 
 DEFAULT_VAE_NAME = None
@@ -37,17 +36,17 @@ DEFAULT_LORA = None
 DEFAULT_POS_PREPROMPT = "score_9, score_8_up, score_7_up, "
 DEFAULT_NEG_PREPROMPT = "score_4, score_3, score_2, score_1, worst quality, bad hands, bad feet, "
 
-DEFAULT_POSITIVE_PROMPT = "safe"
-DEFAULT_NEGATIVE_PROMPT = ""
-
-DEFAULT_HEIGHT = 1024
-DEFAULT_WIDTH = 1024
-
-DEFAULT_STEPS = 35
-DEFAULT_SCHEDULER = SCHEDULER_NAMES[0]
+DEFAULT_POSITIVE_PROMPT = "1girl"
+DEFAULT_NEGATIVE_PROMPT = "animal, cat, dog, big breasts"
 
 DEFAULT_CFG = 7
 DEFAULT_GUIDANCE = 0.7
 
-# Clip Skip is calculated in the same way AUTOMATIC1111 or CivitAI
+# Clip Skip is calculated in the same way AUTOMATIC1111 or CivitAI.
 DEFAULT_CLIP_SKIP = 1
+
+DEFAULT_WIDTH = 1184
+DEFAULT_HEIGHT = 864
+
+DEFAULT_SCHEDULER = SCHEDULER_NAMES[0]
+DEFAULT_STEPS = 35

--- a/constants.py
+++ b/constants.py
@@ -1,31 +1,53 @@
 import finders # finders.py
 import requests
 import torch
+from schedulers import SDXLCompatibleSchedulers # schedulers.py
 
 TORCH_DTYPE = torch.bfloat16
-
-MODELS_DIR_PATH = "models"
-MODELS = finders.find_models(MODELS_DIR_PATH)
+REQUESTS_GLOBAL_SESSION = requests.Session()
 
 # When set to True, the script will offload inactive models to CPU, this will add 3 seconds of overhead when switching models.
 # When set to False, the script won't offload inactive models to CPU, all models will be in GPU which means they will use VRAM,
 # but it should make switching models way faster because the script won't need to move the models between RAM and VRAM.
 CPU_OFFLOAD_INACTIVE_MODELS = False
 
+MODELS_DIR_PATH = "models"
+MODELS = finders.find_models(MODELS_DIR_PATH)
+MODEL_NAMES = list(MODELS)
+
 VAES_DIR_PATH = "vaes"
 VAE_NAMES = finders.find_vaes(VAES_DIR_PATH)
 VAE_NAMES.sort()
-
-DEFAULT_VAE_NAME = None
-BAKEDIN_VAE_LABEL = "default"
-DEFAULT_VAE_NAME = BAKEDIN_VAE_LABEL if DEFAULT_VAE_NAME is None else DEFAULT_VAE_NAME
 
 LORAS_DIR_PATH = "loras"
 MAX_LORA_CACHE_BYTES = 137438953472 # 128 GB.
 
 TEXTUAL_INVERSION_PATHS = finders.find_textual_inversions("textual_inversions")
 
-REQUESTS_GLOBAL_SESSION = requests.Session()
+SCHEDULER_NAMES = SDXLCompatibleSchedulers.get_names()
 
-POSITIVE_PREPROMPT = "score_9, score_8_up, score_7_up, "
-NEGATIVE_PREPROMPT = "score_4, score_3, score_2, score_1, worst quality, bad hands, bad feet, "
+
+DEFAULT_MODEL = MODEL_NAMES[0]
+
+DEFAULT_VAE_NAME = None
+BAKEDIN_VAE_LABEL = "default"
+
+DEFAULT_LORA = None
+
+DEFAULT_POS_PREPROMPT = "score_9, score_8_up, score_7_up, "
+DEFAULT_NEG_PREPROMPT = "score_4, score_3, score_2, score_1, worst quality, bad hands, bad feet, "
+
+DEFAULT_POSITIVE_PROMPT = "safe"
+DEFAULT_NEGATIVE_PROMPT = ""
+
+DEFAULT_HEIGHT = 1024
+DEFAULT_WIDTH = 1024
+
+DEFAULT_STEPS = 35
+DEFAULT_SCHEDULER = SCHEDULER_NAMES[0]
+
+DEFAULT_CFG = 7
+DEFAULT_GUIDANCE = 0.7
+
+# Clip Skip is calculated in the same way AUTOMATIC1111 or CivitAI
+DEFAULT_CLIP_SKIP = 1

--- a/predict.py
+++ b/predict.py
@@ -3,7 +3,7 @@ DEFAULT_VAE_NAME = BAKEDIN_VAE_LABEL if DEFAULT_VAE_NAME is None else DEFAULT_VA
 
 assert len(MODELS) > 0, f"You don't have any model under \"{MODELS_DIR_PATH}\", please put at least 1 model in there!"
 assert DEFAULT_VAE_NAME == BAKEDIN_VAE_LABEL or DEFAULT_VAE_NAME in VAE_NAMES, f"You have set a default VAE but it's not found under \"{VAES_DIR_PATH}\"!"
-assert DEFAULT_CLIP_SKIP > 0, f"Clip Skip must be at least 1 (which is no skip), this is the behavior in A1111 so it's aligned to it!"
+assert DEFAULT_CLIP_SKIP >= 1, f"CLIP skip must be at least 1 (which is no skip), this is the behavior in A1111 so it's aligned to it!"
 
 from cog import BasePredictor, Input, Path
 import utils # utils.py


### PR DESCRIPTION
A whole bunch of new default constants. Renamed `POSITIVE_PREPROMPT` to `DEFAULT_POS_PREPROMPT` and similar for the negative. Then I moved stuff around in `constants.py` until their order made a bit more sense without breaking things.

Moved `DEFAULT_VAE_NAME = BAKEDIN_VAE_LABEL if DEFAULT_VAE_NAME is None else DEFAULT_VAE_NAME` to the top of `predict.py`, added an assert for the clip skip, and the list of scheduler names is now done from within `constants.py`.

I made sure that the cog compiled (whatever the hell it does) and it spat out an image just fine.